### PR TITLE
Handle both older and the current version of Rubocop

### DIFF
--- a/Commands/Analyise file.tmCommand
+++ b/Commands/Analyise file.tmCommand
@@ -7,6 +7,7 @@
 	<key>command</key>
 	<string>#!/usr/bin/env bash
 
+[[ -f "$HOME/.rvm/scripts/rvm" ]] &amp;&amp; . "$HOME/.rvm/scripts/rvm"
 cd "$TM_PROJECT_DIRECTORY"
 ruby "$TM_BUNDLE_SUPPORT/bin/analyse_current_file"</string>
 	<key>input</key>

--- a/Support/lib/mate/env.rb
+++ b/Support/lib/mate/env.rb
@@ -3,13 +3,13 @@ module Mate
   module Env
     # Boilder plate
     module InstanceMethods
-      
+
       def project_path
-        File.expand_path(ENV['TM_PROJECT_DIRECTORY']) 
+        File.expand_path(ENV['TM_PROJECT_DIRECTORY'])
         rescue
           File.dirname(single_file)
       end
-      
+
       def vendor_path
         File.expand_path(ENV['TM_BUNDLE_SUPPORT'] + '/vendor')
       end
@@ -19,20 +19,20 @@ module Mate
           File.expand_path(path)
         end
       end
-  
+
       def single_file
         File.expand_path(ENV['TM_FILEPATH'])
       end
-      
+
       def users_first_name
-        users_names.first.capitalize || '' 
+        users_names.first.capitalize || ''
       end
-        
+
       def users_names
         ENV['TM_FULLNAME'].split(' ')
       end
     end
-    
+
     def self.included(receiver)
       receiver.send :include, InstanceMethods
     end

--- a/Support/lib/mate/env.rb
+++ b/Support/lib/mate/env.rb
@@ -1,13 +1,26 @@
 module Mate
   # Various methods that deal with the TextMate env
   module Env
+    def self.load_bundler
+      path = File.join(project_path, 'Gemfile')
+      if File.exist?(path)
+        gemfile = File.read(path)
+        # Only load bundler if the Gemfile actually contains "rubocop"
+        require 'bundler/setup' if gemfile.include?('rubocop')
+      end
+    end
+
+    def self.project_path
+      File.expand_path(ENV['TM_PROJECT_DIRECTORY'])
+      rescue
+        File.dirname(single_file)
+    end
+
     # Boilder plate
     module InstanceMethods
 
       def project_path
-        File.expand_path(ENV['TM_PROJECT_DIRECTORY'])
-        rescue
-          File.dirname(single_file)
+        Mate::Env.project_path
       end
 
       def vendor_path

--- a/Support/lib/mate/formatter/base.rb
+++ b/Support/lib/mate/formatter/base.rb
@@ -2,17 +2,18 @@ require 'pathname'
 require 'erb'
 require ENV['TM_BUNDLE_SUPPORT'] + '/lib/mate/formatter/inspected_file.rb'
 require ENV['TM_BUNDLE_SUPPORT'] + '/lib/mate/formatter/template_helpers.rb'
+require ENV['TM_BUNDLE_SUPPORT'] + '/lib/mate/proxy.rb'
 
 module Mate
   module Formatter
     # This is used to format the response from rubocop
     # This is heavily influenced by the json formatter
-    class Base < Rubocop::Formatter::BaseFormatter
+    class Base < Proxy.rubocop::Formatter::BaseFormatter
       include ERB::Util
       include TemplateHelpers
       attr_reader :files, :summary, :files
 
-      def initialize(output)
+      def initialize(*args)
         super
         @files = []
         @summary = { offence_count: 0 }
@@ -34,7 +35,7 @@ module Mate
 
       def metadata
         {
-          :'RuboCop version' => Rubocop::Version::STRING,
+          :'RuboCop version' => Proxy.rubocop::Version::STRING,
           :'Ruby engine'     => RUBY_ENGINE,
           :'Ruby version'    => RUBY_VERSION,
           :'Ruby patchlevel' => RUBY_PATCHLEVEL.to_s,

--- a/Support/lib/mate/formatter/template_helpers.rb
+++ b/Support/lib/mate/formatter/template_helpers.rb
@@ -8,33 +8,33 @@ module Mate
     module TemplateHelpers
       module InstanceMethods
         include Mate::Env
-        
+
         def url_to(file, line = nil, column = nil)
-          # for reference 
+          # for reference
           # http://blog.macromates.com/2007/the-textmate-url-scheme/
           out = "txmt://open?url=file://#{File.expand_path(file.path)}"
           out += "&line=#{line}" if line
           out += "&column=#{column}" if column
           out
         end
-        
+
         def fixed_class(val)
           val ? 'fixed' : 'not_fixed'
         end
-        
+
         def fixed_message(val)
           "This has #{val ? 'has' : 'has not'} been fixed automatically"
         end
-        
+
         def class_for_issue(issue)
           ['wrapper', issue.severity, fixed_class(issue.corrected?)].join(' ')
         end
-        
+
         # Remove the project
         def filename(file)
           file.path.sub(project_path, '')
         end
-        
+
         def offences_message
           case @summary[:offence_count]
           when 0
@@ -45,20 +45,20 @@ module Mate
             "#{@summary[:offence_count]} offences"
           end
         end
-        
+
         def file_count
           @files.length > 1 ? "#{@files.length} files" : '1 file'
         end
-        
+
         def partial(file, options = {})
-          # rubocop considers the next line 'useless', 
+          # rubocop considers the next line 'useless',
           # but is used by erb with it's binding
           # i'm' not sure how else to implement it
           f = options[:f]
           ERB.new(File.read(template_path(file))).result(binding)
         end
       end
-      
+
       def self.included(receiver)
         receiver.send :include, InstanceMethods
       end

--- a/Support/lib/mate/proxy.rb
+++ b/Support/lib/mate/proxy.rb
@@ -14,6 +14,10 @@ class Proxy
     new(options).run!
   end
 
+  def self.rubocop
+    defined?(RuboCop) ? RuboCop : Rubocop
+  end
+
   attr_accessor :options, :files, :which_rubocop
 
   def initialize(args)
@@ -23,7 +27,7 @@ class Proxy
   end
 
   def run!
-    Rubocop::CLI.new.run(runtime_options)
+    self.class.rubocop::CLI.new.run(runtime_options)
   end
 
   private

--- a/Support/lib/mate/proxy.rb
+++ b/Support/lib/mate/proxy.rb
@@ -1,6 +1,8 @@
 require 'rubygems'
 require ENV['TM_BUNDLE_SUPPORT'] + '/lib/mate/env.rb'
 
+Mate::Env.load_bundler
+
 # Try to detect where rubocop is installed on the users system
 # Attempts to load rubocop from the following locations
 #

--- a/Support/lib/mate/proxy.rb
+++ b/Support/lib/mate/proxy.rb
@@ -3,17 +3,17 @@ require ENV['TM_BUNDLE_SUPPORT'] + '/lib/mate/env.rb'
 
 # Try to detect where rubocop is installed on the users system
 # Attempts to load rubocop from the following locations
-# 
+#
 # * system path
 # * project
 # * embedded version
 class Proxy
   include Mate::Env
-  
+
   def self.run!(options)
     new(options).run!
   end
-  
+
   attr_accessor :options, :files, :which_rubocop
 
   def initialize(args)
@@ -21,7 +21,7 @@ class Proxy
     @files         = [args[:files]].flatten
     @which_rubocop = load_rubocop
   end
-  
+
   def run!
     Rubocop::CLI.new.run(runtime_options)
   end
@@ -31,7 +31,7 @@ class Proxy
   def runtime_options
     options_to_a.concat(files)
   end
-  
+
   def options_to_a
     options.each_pair.reduce([]) do |obj, key_value|
       obj << "--#{key_value[0]}"
@@ -43,14 +43,14 @@ class Proxy
   def load_rubocop
     system_rubocop || project_rubocop || embedded_rubocop
   end
-  
+
   def system_rubocop
     require 'rubocop'
     :system
     rescue LoadError
       false
   end
-  
+
   def project_rubocop
     $LOAD_PATH << project_path unless $LOAD_PATH.member?(project_path)
     require 'rubocop'
@@ -58,15 +58,15 @@ class Proxy
     rescue LoadError
       false
   end
-  
+
   def embedded_rubocop
     ENV['GEM_HOME'] = vendor_path
-    Gem.clear_paths 
+    Gem.clear_paths
 
     require 'rubocop'
     :embedded
   end
- 
+
   def custom_formatter_options
     {
       require: File.expand_path(ENV['TM_BUNDLE_SUPPORT'] + '/lib/mate/formatter/base.rb'),

--- a/Support/spec/mate/env_spec.rb
+++ b/Support/spec/mate/env_spec.rb
@@ -7,25 +7,25 @@ class Dummy
 end
 
 describe 'mate env' do
-  
+
   it 'should define a project_path' do
     Dummy.new.project_path.should =~ /Support/
   end
-  
+
   it 'should define a vendor_path' do
     Dummy.new.vendor_path.should =~ /Support\/vendor/
   end
-  
+
   it 'should define a multiple_files' do
     Dummy.new.multiple_files.should_not be_empty
   end
-  
+
   it 'should define single_file' do
     Dummy.new.single_file.should =~ /Support/
   end
-  
+
   describe 'names' do
-    
+
     ['John', 'John Smith', 'John Doe'].each do |val|
 
       before(:each) do
@@ -36,15 +36,15 @@ describe 'mate env' do
         Dummy.new.users_first_name.should =~ /jo/i
       end
     end
-    
+
     it 'should have an array of names' do
       Dummy.new.users_names.length.should be(2)
     end
-    
+
     it "should not return anyting if the TM_FULLNAME is not set" do
       ENV['TM_FULLNAME'] = ''
       Dummy.new.users_first_name.should == ''
     end
-  
+
   end
 end

--- a/Support/spec/mate/runner_spec.rb
+++ b/Support/spec/mate/runner_spec.rb
@@ -2,23 +2,23 @@ require 'spec_helper'
 
 
 describe "Mate runner" do
-  
+
   before(:each) do
     tm_selected_files(__FILE__)
     @runner = Mate::Runner.new
   end
-  
+
   # it "should be able to run" do
   #   pending 'this is super noisy'
   #   # lambda { @runner.current_file }.should_not raise_error
   # end
-  
+
   it "should have project_path" do
     @runner.send(:project_path).should =~ /Support/
   end
-  
+
   it "should responed to multiple_files" do
     @runner.send(:multiple_files).should_not be_empty
   end
-  
+
 end

--- a/Support/templates/result.erb
+++ b/Support/templates/result.erb
@@ -3,105 +3,105 @@
 <head>
   <title><%= offences_message %> from <%= file_count %> | RuboCop</title>
   <style type="text/css" media="screen">
-  
+
     body {
       font: normal 10pt Verdana, sans-serif;
       margin: 0;
       body: 0;
     }
-    
+
     h1, h2, h3, h4, th {
       font-weight: 600;
       font-size: 1em;
       padding: 0;
       margin: 0;
     }
-    
+
     ol, ol li {
       list-style: none;
       margin: 0;
       padding: 0;
     }
-    
+
     a {
       display: inline-block;
       padding: 0.25em;
     }
-    
+
     .wrapper {
       padding: 0.5em 1.5em;
     }
-        
-    /*    
+
+    /*
       Offences, posible values...
-      * refactor 
-      * convention 
-      * warning 
+      * refactor
+      * convention
+      * warning
       * error
       * fatal
     */
-    
+
     .refactor {
       background-color: #FB4F5F;
     }
-    
+
     .convention {
       background-color: #DDDDDC;
     }
-    
+
     .warning {
       background-color: #FFFA65;
     }
-    
+
     .error {
       background-color: #FF6700;
     }
-    
+
     .fatal {
       color: #fff;
       background-color: #CC0920;
     }
-    
+
     .good {
       background-color: #73B532;
     }
-    
+
     .file_report {
       margin-bottom: 1em;
     }
-    
+
     .filename::before {
       content: '📄';
     }
-    
+
     .auto-corrected {
       float: right;
     }
-    
+
     .cop_name, footer, footer a {
       color: rgba(0,0,0,0.5);s
     }
-    
+
     #metadata, #help {
       font-size: 0.75em;
       margin-bottom: 1em;
       display: inline-block;
     }
-    
+
     #metadata th, #metadata td {
       text-align: left;
       padding-right: 0.75em;
       font-weight: 400;
     }
-    
+
     #help {
       float: right;
     }
-    
+
   </style>
 </head>
 <body>
-  
+
   <% @files.each do |f| %>
     <div class="file_report">
       <h4 class="wrapper filename">


### PR DESCRIPTION
I bundled together a couple of changes:
- Handle both older and the current version of Rubocop (#7)
- Add support for Bundler (#7)
- Add support for RVM
